### PR TITLE
Coverage decrease

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,7 +2,5 @@ import { render, screen } from '@testing-library/react';
 import App from './App';
 
 test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  // no more test!
 });


### PR DESCRIPTION
Notice how "No Coverage information" is provided in the sonarcloud analysis despite the fact that a test was removed and coverage should be decreased! This is due to the fact that sonarcloud only analyzes “New Code” for coverage in PRs - this means if tests are accidentally deleted that are unrelated to the new production code in a PR, you will not see the coverage go down as expected!